### PR TITLE
Fix regex for version strings containing regex reserved characters

### DIFF
--- a/libraries/provider_default.rb
+++ b/libraries/provider_default.rb
@@ -26,18 +26,19 @@ class Chef
         # EPOCH:NAME-VERSION-RELEASE.ARCH
         version_string = "#{new_resource.epoch}:#{new_resource.package}-#{new_resource.version}-#{new_resource.release}.#{new_resource.arch}"
         resource_action = new_resource.action.is_a?(Array) ? new_resource.action.first.to_s : new_resource.action.to_s
+        pattern_string = Regexp.quote(version_string)
 
         ruby_block "#{resource_action} yum_version_lock #{version_string}" do
           block do
             fe = Chef::Util::FileEdit.new(node['yum-plugin-versionlock']['locklist'])
             case resource_action
             when 'add'
-              fe.insert_line_if_no_match(/#{version_string}/, version_string)
+              fe.insert_line_if_no_match(/#{pattern_string}/, version_string)
             when 'update'
               fe.search_file_replace_line(/^[0-9]+:#{new_resource.package}-.+-.+\./, version_string)
-              fe.insert_line_if_no_match(/#{version_string}/, version_string)
+              fe.insert_line_if_no_match(/#{pattern_string}/, version_string)
             when 'remove'
-              fe.search_file_delete_line(/#{version_string}/)
+              fe.search_file_delete_line(/#{pattern_string}/)
             end
             fe.write_file
           end


### PR DESCRIPTION
The regex was causing problems for packages containing regex reserved characters in their name, such as libstdc++. 