### PR TITLE
Add support for CentOS 8

### DIFF
--- a/resources/yum_version_lock.rb
+++ b/resources/yum_version_lock.rb
@@ -10,8 +10,14 @@ default_action :add
 
 action_class do
   def set_yum_version_lock
-    # EPOCH:NAME-VERSION-RELEASE.ARCH
-    version_string = "#{new_resource.epoch}:#{new_resource.package}-#{new_resource.version}-#{new_resource.release}.#{new_resource.arch}"
+    version_string =
+      if node['platform_version'].to_i >= 8
+        # NAME-VERSION-EPOCH:RELEASE.ARCH
+        "#{new_resource.package}-#{new_resource.epoch}:#{new_resource.version}-#{new_resource.release}.#{new_resource.arch}"
+      else
+        # EPOCH:NAME-VERSION-RELEASE.ARCH
+        "#{new_resource.epoch}:#{new_resource.package}-#{new_resource.version}-#{new_resource.release}.#{new_resource.arch}"
+      end
     resource_action = new_resource.action.is_a?(Array) ? new_resource.action.first.to_s : new_resource.action.to_s
     pattern_string = Regexp.quote(version_string)
 
@@ -22,7 +28,11 @@ action_class do
         when 'add'
           fe.insert_line_if_no_match(/#{pattern_string}/, version_string)
         when 'update'
-          fe.search_file_replace_line(/^[0-9]+:#{new_resource.package}-.+-.+\./, version_string)
+          if node['platform_version'].to_i >= 8
+            fe.search_file_replace_line(/^#{new_resource.package}-[0-9]+:.+\./, version_string)
+          else
+            fe.search_file_replace_line(/^[0-9]+:#{new_resource.package}-.+-.+\./, version_string)
+          end
           fe.insert_line_if_no_match(/#{pattern_string}/, version_string)
         when 'remove'
           fe.search_file_delete_line(/#{pattern_string}/)


### PR DESCRIPTION
In RHEL/CentOS 8 and onward, dnf-versionlock (which replaced yum-versionlock)
has changed the format of the by moving the placement of the Epoch to a
different location.

Instead of:

``EPOCH:NAME-VERSION-RELEASE.ARCH``

It should be:

``NAME-VERSION-EPOCH:RELEASE.ARCH``