### PR TITLE
Remove duplicate lines on update action

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,6 +5,7 @@ driver:
 provisioner:
   name: chef_solo
   deprecations_as_errors: true
+  multiple_converge: 2
 
 platforms:
   - name: centos-6
@@ -23,4 +24,3 @@ suites:
       - recipe[test::idempotency]
     provisioner:
       enforce_idempotency: true
-      multiple_converge: 2

--- a/resources/yum_version_lock.rb
+++ b/resources/yum_version_lock.rb
@@ -39,6 +39,7 @@ action :update do
     path node["yum-plugin-versionlock"]["locklist"]
     pattern line_regex
     line version_string
+    remove_duplicates true
   end
 end
 

--- a/test/integration/default/lwrp_spec.rb
+++ b/test/integration/default/lwrp_spec.rb
@@ -19,3 +19,8 @@ else
     its("content") { should_not match "0:yum-3.4.3-150.x86_64" }
   end
 end
+
+# check for duplicates from :update
+describe command("sort /etc/yum/pluginconf.d/versionlock.list | uniq --count") do
+  its('stdout') { should match /1 (0:)?grep/ }
+end


### PR DESCRIPTION
Fixes #23.

The `line` cookbook resource used for the `:update` action has a built-in property to remove duplicates; this enables it.

This also adds an additional test to the default suite to validate that the grep update resource does not add any duplicate lines on subsequent converges.

