### PR TITLE
Fix CHEF-33 deprecation issue

### DIFF
--- a/resources/yum_version_lock.rb
+++ b/resources/yum_version_lock.rb
@@ -1,5 +1,6 @@
 resource_name :yum_version_lock
 provides :yum_version_lock
+unified_mode true if respond_to?(:unified_mode)
 
 property :package, String, name_property: true
 property :epoch, [String, Integer], default: "0"


### PR DESCRIPTION
This PR fixes the following issue with recent chef-infra clients:

```
[2021-07-01T13:20:07+00:00] ERROR: Deprecation CHEF-33 from /opt/kitchen/cache/cookbooks/yum-plugin-versionlock/resources/yum_version_lock.rb

  The yum_version_lock resource in the yum-plugin-versionlock cookbook should declare `unified_mode true`

Please see https://docs.chef.io/deprecations_unified_mode/ for further details and information on how to correct this problem.
```
