### PR TITLE
prevent the accidental murder of the first item already existing in the list

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -23,3 +23,7 @@ suites:
       - recipe[test::idempotency]
     provisioner:
       enforce_idempotency: true
+  - name: existing
+    run_list:
+      - recipe[test::existing]
+      - recipe[test::lwrp]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -6,8 +6,10 @@ module YumPluginVersionlock
         if ::File.exist?(filepath) && !::File.zero?(filepath)
           locks = {}
           begin
-            content = ::File.read(node["yum-plugin-versionlock"]["locklist"]).split("\n\n").drop(1)
+            content = ::File.read(node["yum-plugin-versionlock"]["locklist"]).split("\n\n")
             content.each do |l|
+              next unless l.match(/# .+\n.+/)
+              next if l.match(/# Managed by Chef!.*\n# Changes will be overwritten!.*/)
               _, package, lock_string = l.split(/# (.+)\n(.+)/)
               locks[package] = lock_string
             end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -8,8 +8,8 @@ module YumPluginVersionlock
           begin
             content = ::File.read(node["yum-plugin-versionlock"]["locklist"]).split("\n\n")
             content.each do |l|
-              next unless l.match(/# .+\n.+/)
-              next if l.match(/# Managed by Chef!.*\n# Changes will be overwritten!.*/)
+              next unless l =~ /# .+\n.+/
+              next if l =~ /# Managed by Chef!.*\n# Changes will be overwritten!.*/
               _, package, lock_string = l.split(/# (.+)\n(.+)/)
               locks[package] = lock_string
             end

--- a/test/cookbooks/test/recipes/existing.rb
+++ b/test/cookbooks/test/recipes/existing.rb
@@ -1,4 +1,4 @@
-bash 'add a lock by hand' do
+bash "add a lock by hand" do
   code 'echo "# subscription-manager" >> /etc/yum/pluginconf.d/versionlock.list; echo "0:subscription-manager-1.17.6-1.el6.x86_64" >> /etc/yum/pluginconf.d/versionlock.list'
   action :nothing
 end.run_action(:run)

--- a/test/cookbooks/test/recipes/existing.rb
+++ b/test/cookbooks/test/recipes/existing.rb
@@ -1,0 +1,4 @@
+bash 'add a lock by hand' do
+  code 'echo "# subscription-manager" >> /etc/yum/pluginconf.d/versionlock.list; echo "0:subscription-manager-1.17.6-1.el6.x86_64" >> /etc/yum/pluginconf.d/versionlock.list'
+  action :nothing
+end.run_action(:run)

--- a/test/cookbooks/test/recipes/lwrp.rb
+++ b/test/cookbooks/test/recipes/lwrp.rb
@@ -43,6 +43,19 @@ yum_version_lock "yum" do
 end
 
 # Test that locks actually work
+# in 7, libgomp dep fails if not managed with same version of gcc
+yum_version_lock 'libgomp' do
+  version "4.8.5"
+  release "39.el7"
+  action :update
+  not_if { node['platform_version'].to_i == 8 }
+end
+
+package "libgomp" do
+  action :upgrade
+  not_if { node['platform_version'].to_i == 8 }
+end
+
 yum_version_lock "gcc" do
   case node["platform_version"].to_i
   when 7
@@ -50,7 +63,7 @@ yum_version_lock "gcc" do
     release "39.el7"
   when 8
     version "8.3.1"
-    release "5.el8.0.2"
+    release "5.el8"
   end
   action :update
 end

--- a/test/cookbooks/test/recipes/lwrp.rb
+++ b/test/cookbooks/test/recipes/lwrp.rb
@@ -44,16 +44,16 @@ end
 
 # Test that locks actually work
 # in 7, libgomp dep fails if not managed with same version of gcc
-yum_version_lock 'libgomp' do
+yum_version_lock "libgomp" do
   version "4.8.5"
   release "39.el7"
   action :update
-  not_if { node['platform_version'].to_i == 8 }
+  not_if { node["platform_version"].to_i == 8 }
 end
 
 package "libgomp" do
   action :upgrade
-  not_if { node['platform_version'].to_i == 8 }
+  not_if { node["platform_version"].to_i == 8 }
 end
 
 yum_version_lock "gcc" do
@@ -63,7 +63,7 @@ yum_version_lock "gcc" do
     release "39.el7"
   when 8
     version "8.3.1"
-    release "5.el8"
+    release "5.el8.0.2"
   end
   action :update
 end

--- a/test/integration/existing/default_spec.rb
+++ b/test/integration/existing/default_spec.rb
@@ -1,0 +1,34 @@
+title "Package and Plugin Configuration"
+
+if os["release"][0].to_i >= 8
+  describe package("python3-dnf-plugin-versionlock") do
+    it { should be_installed }
+  end
+
+  describe file("/etc/dnf/plugins/versionlock.conf") do
+    it { should exist }
+    it { should be_a_file }
+    its("mode") { should cmp "0644" }
+    its("content") { should match(/enabled = [01]/) }
+    its("content") { should match(%r{locklist = /[^\0]+}) }
+    its("content") { should match(/follow_obsoletes = [01]/) }
+  end
+
+  describe file("/etc/yum/pluginconf.d") do
+    it { should exist }
+    it { should be_symlink }
+  end
+else
+  describe package("yum-plugin-versionlock") do
+    it { should be_installed }
+  end
+
+  describe file("/etc/yum/pluginconf.d/versionlock.conf") do
+    it { should exist }
+    it { should be_a_file }
+    its("mode") { should cmp "0644" }
+    its("content") { should match(/enabled = [01]/) }
+    its("content") { should match(%r{locklist = /[^\0]+}) }
+    its("content") { should match(/follow_obsoletes = [01]/) }
+  end
+end

--- a/test/integration/existing/lwrp_spec.rb
+++ b/test/integration/existing/lwrp_spec.rb
@@ -1,0 +1,41 @@
+title "LWRP Functionality"
+
+if os["release"][0].to_i >= 8
+  describe file("/etc/dnf/plugins/versionlock.list") do
+    it { should exist }
+    it { should be_file }
+    its("content") { should match "rpm-0:4.11.3-21.x86_64" }
+    its("content") { should match "sed-0:4.2.2-5.x86_64" }
+    its("content") { should match "grep-0:2.20-4.x86_64" }
+    its("content") { should_not match "yum-0:3.4.3-150.x86_64" }
+  end
+else
+  describe file("/etc/yum/pluginconf.d/versionlock.list") do
+    it { should exist }
+    it { should be_file }
+    its("content") { should match "0:subscription-manager-1.17.6-1.el6.x86_64" }
+    its("content") { should match "0:rpm-4.11.3-21.x86_64" }
+    its("content") { should match "0:sed-4.2.2-5.x86_64" }
+    its("content") { should match "0:grep-2.20-4.x86_64" }
+    its("content") { should_not match "0:yum-3.4.3-150.x86_64" }
+  end
+end
+
+# check for duplicates from :update
+describe command("sort /etc/yum/pluginconf.d/versionlock.list | uniq --count") do
+  its("stdout") { should match /1 (0:)?grep/ }
+end
+
+# verify that the correct locked version of GCC was installed
+case os.release.to_i
+when 7
+  describe command("yum list installed gcc") do
+    its("stdout") { should match /gcc.x86_64 +4.8.5-39.el7 +@centos-vault-7.8.2003-base/ }
+    its("stdout") { should_not match /gcc.x86_64 +4.8.5-44.el7 +@base/ }
+  end
+when 8
+  describe command("yum list installed gcc") do
+    its("stdout") { should match /gcc.x86_64 +8.3.1-5.el8.0.2 +@centos-vault-8.2.2004-appstream/ }
+    its("stdout") { should_not match /gcc.x86_64 +8.3.1-5.el8 +@appstream/ }
+  end
+end


### PR DESCRIPTION
In the case where some version locks exist on the system prior to the first use of `yum_version_lock`, the library method that parses the existing version locks assumes that the chef header is already there, but on the first use of the resource it does not. To resolve, instead of skipping the first item in the list we check for the chef header. 

Note that I had to alter the test fixture cookbook a bit to make it work with modern centos-7, and while I tried to get centos-8 replaced with centos-stream-8, I failed, and then ran out of time.